### PR TITLE
Util function seperation / README corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instructions:
 ------------
 
 Associate a new gateway on Portal. 
-Enter the same GatewayId in /src/config.ts
+Enter the same GatewayId in /src/main.ts
 
 ```
 npm install
@@ -20,7 +20,11 @@ npm install
 In another terminal:
 
 ```
-npm start
+npm run buildwatch
+```
+
+```
+npm run start
 ```
 
 Features:

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ var iotnxtqueue = new iotnxt.IotnxtQueue(
     GatewayId: "TutorialGateway01",
     //secret is your password to connect the Gateway, this cannot be changed , dont share with anyone!
     secretkey: "166123181241239",
-    FirmwareVersion: "5.0.25",
+    FirmwareVersion: "5.0.26",
     Make:  "Pi Gateway",
     Model: "nodejs client",
     id: "Pi 3 B",

--- a/src/utils/crypto.utils.ts
+++ b/src/utils/crypto.utils.ts
@@ -1,0 +1,67 @@
+import crypto = require("crypto");
+
+
+export interface RSAcredentials {
+    modulus: string,
+    exponent: string
+}
+
+export class CryptoUtils {
+    
+    public static RSAENCRYPT(text: string, credentials: RSAcredentials) {
+        // https://stackoverflow.com/questions/27568570/how-to-convert-raw-modulus-exponent-to-rsa-public-key-pem-format
+    
+        var publicKey = this.RSAgenPEM(credentials.modulus, credentials.exponent);
+        var buffer = Buffer.from(text);
+    
+        var rsakey = {
+            key: publicKey,
+            padding: 1 //crypto.constants.RSA_PKCS1_PADDING  
+        }
+    
+        //An optional padding value defined in crypto.constants, which may be: crypto.constants.RSA_NO_PADDING, RSA_PKCS1_PADDING, or crypto.constants.RSA_PKCS1_OAEP_PADDING.
+    
+        var encrypted = crypto.publicEncrypt(rsakey, buffer);
+        return encrypted.toString("base64");
+    }
+    
+    public static  RSAgenPEM(modulus: string, exponent: string) {
+        // by Rouan van der Ende
+        // converts a raw modulus/exponent public key to a PEM format.
+    
+        var header = Buffer.from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA", 'base64'); //Standard header
+        var mod = Buffer.from(modulus, 'base64');
+        var midHeader = Buffer.from([0x02, 0x03]);
+        var exp = Buffer.from(exponent, 'base64');
+    
+        //combine
+        var key = Buffer.concat([header, mod, midHeader, exp])
+        var keybase64 = key.toString("base64");
+    
+        var PEM = "-----BEGIN PUBLIC KEY-----\r\n"
+    
+        for (var a = 0; a <= Math.floor(keybase64.length / 64); a++) {
+            PEM += keybase64.slice(0 + (64 * a), 64 + (64 * a)) + "\r\n";
+        }
+    
+        PEM += "-----END PUBLIC KEY-----\r\n"
+    
+        return PEM;
+    }
+    
+    public static  genAESkeys (callback:any) {
+          crypto.pseudoRandomBytes(32, function (err, keyBuffer) {
+              crypto.pseudoRandomBytes(16, function (err, ivBuffer) {
+                  callback({ key: keyBuffer, iv: ivBuffer });
+              });
+          });
+    }
+    
+    public static  createCipheriv(AES: any, algorithm: string = "aes-256-cbc"): crypto.Cipher {
+        return crypto.createCipheriv(algorithm, AES.key, AES.iv);
+    }
+    
+    public static  createDecipheriv(AES: any, algorithm: string = "aes-256-cbc"): crypto.Decipher {
+        return crypto.createDecipheriv(algorithm, AES.key, AES.iv);
+    }
+}

--- a/src/utils/string.utils.ts
+++ b/src/utils/string.utils.ts
@@ -1,0 +1,11 @@
+export class StringUtils {
+    public static  getGUID() {
+        var d = new Date().getTime();
+        var uuid: string = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = (d + Math.random() * 16) % 16 | 0;
+            d = Math.floor(d / 16);
+            return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+        });
+        return uuid;
+      };
+}


### PR DESCRIPTION
Featured changes (Firmware v5.0.26)
----
**Changes**
* Separate crypto/string util functions from queue logic
----
**Fixes**
* Correct startup instructions in README which don't instruct user to build first with ```npm run buildwatch```
* Correct startup instructions in README which should point gatewayID setup to ```main.ts``` and NOT ```config.ts```
