### PR TITLE
Unit tests [initial] - String util & Queue code, README corrections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/build/main.js"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program with out",
+            "program": "${workspaceFolder}\\build\\main.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch current file w/ ts-node",
+            "protocol": "inspector",
+            "args": [
+                "${workspaceRoot}/src/main.ts"
+            ],
+            "cwd": "${workspaceRoot}",
+            "runtimeArgs": [
+                "-r",
+                "ts-node/register"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "preLaunchTask": "build"
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "build",
+            "problemMatcher": [],
+            "identifier": "build"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ npm run start
 Features:
 ---------
 
-- sqlite persistance layer
 - bandwidth optimized publish algorithm that diff's data before sending
 
 Planned:
 --------
 
+- sqlite persistance layer
 - Locally hosted web interface
 
 Tips:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instructions:
 ------------
 
 Associate a new gateway on Portal. 
-Enter the same GatewayId in /src/config.ts
+Enter the same GatewayId in /src/main.ts
 
 ```
 npm install
@@ -20,7 +20,11 @@ npm install
 In another terminal:
 
 ```
-npm start
+npm run buildwatch
+```
+
+```
+npm run start
 ```
 
 Features:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "src/main.js",
   "scripts": {
     "start": "node ./build/main.js",
-    "buildwatch": "tsc --w --lib es2015 ./src/main.ts --outDir ./build"
+    "buildwatch": "tsc --w --lib es2015 ./src/main.ts --outDir ./build",
+    "test": "mocha -r ts-node/register src/tests/**/**.ts",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",
@@ -40,7 +42,12 @@
     "unzipper": "^0.8.14"
   },
   "devDependencies": {
-    "ts-node": "^6.1.1",
-    "typescript": "^2.9.2"
+    "@types/chai": "^4.1.6",
+    "@types/mocha": "^5.2.5",
+    "chai": "^4.2.0",
+    "mocha": "^5.2.0",
+    "ts-node": "^6.2.0",
+    "typescript": "^2.9.2",
+    "typings": "^2.1.1"
   }
 }

--- a/src/iotnxt/iotnxt.ts
+++ b/src/iotnxt/iotnxt.ts
@@ -2,41 +2,40 @@ import * as events from 'events'
 import mqtt = require('mqtt');
 
 //Internal imports
-import { CryptoUtils , RSAcredentials} from './../utils/crypto.utils';
+import { CryptoUtils, RSAcredentials } from './../utils/crypto.utils';
 import { StringUtils } from './../utils/string.utils';
 
 export class IotnxtQueue extends events.EventEmitter {
   a = 0;
-  RoutingKeyBase:any;
-  connected:boolean = false;
-  
+  RoutingKeyBase: any;
+  connected: boolean = false;
+
   state: any = { "deviceGroups": {} };
-  
-  GatewayId:string = "";
-  secretkey:string="";
 
-  secret:any={}; //red queue stuff
+  GatewayId: string = "";
+  secretkey: string = "";
 
-  hostaddress:string = "";
-  Make:string = "";
-  Model:string = "";
-  FirmwareVersion:string = "";
-  Location:string="";
-  
-  Devices:any={};
-  GatewayFirstContact:boolean=false;
-  IsIoTHubDevice:boolean=false;
-  Config:any={};
-  ClientId:string="";
-  modulus:string="";
-  exponent:string="";
-  AES:any={};
+  secret: any = {}; //red queue stuff
 
-  mqttRed:mqtt.MqttClient|any;
+  hostaddress: string = "";
+  Make: string = "";
+  Model: string = "";
+  FirmwareVersion: string = "";
+  Location: string = "";
 
-  constructor(config:any, Devices:any, force:boolean) {
+  Devices: any = {};
+  GatewayFirstContact: boolean = false;
+  IsIoTHubDevice: boolean = false;
+  Config: any = {};
+  ClientId: string = "";
+  modulus: string = "";
+  exponent: string = "";
+  AES: any = {};
+
+  mqttRed: mqtt.MqttClient | any;
+
+  constructor(config: any, Devices: any, force: boolean) {
     super();
-
     this.GatewayId = config.GatewayId;
     this.hostaddress = config.hostaddress;
 
@@ -50,20 +49,22 @@ export class IotnxtQueue extends events.EventEmitter {
     this.exponent = config.publickey.split("<").join(',').split(">").join(',').split(',')[4]
 
     this.Devices = Devices;
+  }
 
-    CryptoUtils.genAESkeys((AES:any)=>{
+  public init(): void {
+    CryptoUtils.genAESkeys((AES: any) => {
       this.AES = AES;
-      this.connectGreenQ((err:Error,secret:any)=>{
+      this.connectGreenQ((err: Error, secret: any) => {
         if (err) console.log(err);
         if (secret) {
           console.log("can now connect to red queue")
-          
-          this.connectRedQ((err:Error,result:any)=>{
+
+          this.connectRedQ((err: Error, result: any) => {
             if (err) console.log(err);
             if (result) {
               console.log(result);
-              this.register((err:Error, result:any)=>{
-                this.mqttRed.subscribe(this.secret.RoutingKeyBase+".REQ", (err:Error)=>{
+              this.register((err: Error, result: any) => {
+                this.mqttRed.subscribe(this.secret.RoutingKeyBase + ".REQ", (err: Error) => {
                   if (err) console.log(err);
                 });
 
@@ -76,19 +77,14 @@ export class IotnxtQueue extends events.EventEmitter {
                 this.emit('connect');
               });
             }
-
-
           });
         }
       });
     })
-
   }
-
-
   /* ################################################################################## */
 
-  connectGreenQ(cb:any) {
+  connectGreenQ(cb: any) {
     var greenOptions = {
       clientId: this.GatewayId + ".GREEN." + ((Date.now() * 10000) + 621355968000000000),
       username: "green1:public1",
@@ -102,9 +98,9 @@ export class IotnxtQueue extends events.EventEmitter {
     var replyKey = "MessageAuthNotify.".toUpperCase() + StringUtils.getGUID().toUpperCase();
     var mqttGreen = mqtt.connect("mqtts://" + this.hostaddress + ":8883", greenOptions);
 
-    mqttGreen.on('error', (err: any) => { cb(err,undefined); })
-    mqttGreen.on("offline", function(err:any) { cb(err,undefined); })
-    mqttGreen.on("close", function(err:any) { cb(err,undefined);  })
+    mqttGreen.on('error', (err: any) => { cb(err, undefined); })
+    mqttGreen.on("offline", function (err: any) { cb(err, undefined); })
+    mqttGreen.on("close", function (err: any) { cb(err, undefined); })
 
     mqttGreen.on('connect', () => {
       console.log("GREEN CONNECTED!")
@@ -127,24 +123,24 @@ export class IotnxtQueue extends events.EventEmitter {
           var newBuffer = Buffer.concat([encrypted, encryptedFinal]);
 
           var RSAcreds: RSAcredentials = {
-              modulus: this.modulus,
-              exponent: this.exponent
+            modulus: this.modulus,
+            exponent: this.exponent
           }
 
           var wrappedMessage = {
-              Payload: newBuffer.toString("base64"),
-              IsEncrypted: true,
-              Headers: {
-                  //SymKey: publicKeyRSA.encrypt(AES.key, "UTF8", "base64", ursa.RSA_PKCS1_PADDING).toString("base64"),
-                  SymIv: CryptoUtils.RSAENCRYPT(this.AES.iv, RSAcreds),
-                  SymKey: CryptoUtils.RSAENCRYPT(this.AES.key, RSAcreds)
-              },
-              PostUtc: new Date().toISOString(),
-              ReplyKey: replyKey.toUpperCase()
+            Payload: newBuffer.toString("base64"),
+            IsEncrypted: true,
+            Headers: {
+              //SymKey: publicKeyRSA.encrypt(AES.key, "UTF8", "base64", ursa.RSA_PKCS1_PADDING).toString("base64"),
+              SymIv: CryptoUtils.RSAENCRYPT(this.AES.iv, RSAcreds),
+              SymKey: CryptoUtils.RSAENCRYPT(this.AES.key, RSAcreds)
+            },
+            PostUtc: new Date().toISOString(),
+            ReplyKey: replyKey.toUpperCase()
           }
 
           mqttGreen.publish("MESSAGEAUTHREQUEST", JSON.stringify(wrappedMessage), { qos: 1 }, function (err: any) {
-              if (err) { console.error("publisherror:" + err) }
+            if (err) { console.error("publisherror:" + err) }
           });
           ///
         }
@@ -159,9 +155,9 @@ export class IotnxtQueue extends events.EventEmitter {
       var decipher = CryptoUtils.createDecipheriv(this.AES);
       var result = Buffer.concat([decipher.update(payload), decipher.final()]);
       var secret = JSON.parse(result.toString());
-      
-      
-      
+
+
+
       mqttGreen.end(undefined, () => {
         console.log("disconnected from green queue cleanly")
         if (secret.Success == true) {
@@ -170,7 +166,7 @@ export class IotnxtQueue extends events.EventEmitter {
         } else {
           cb(secret, undefined);
         }
-        
+
       })
 
     });
@@ -180,8 +176,8 @@ export class IotnxtQueue extends events.EventEmitter {
 
 
 
-  connectRedQ(cb:any) {
-    
+  connectRedQ(cb: any) {
+
     var redoptions = {
       clientId: this.secret.ClientId + ".RED." + ((Date.now() * 10000) + 621355968000000000),
       username: this.secret.vHost + ":" + this.GatewayId,
@@ -191,42 +187,46 @@ export class IotnxtQueue extends events.EventEmitter {
     }
 
     this.mqttRed = mqtt.connect("mqtts://" + this.secret.Hosts[0] + ":8883", redoptions);
-    
-    this.mqttRed.on('connect', () => { 
+
+    this.mqttRed.on('connect', () => {
       console.log("MQTT RED CONNECTED")
       this.connected = true;
-      cb(undefined,true);
+      cb(undefined, true);
     });
 
     this.mqttRed.on('reconnect', function () { console.log("Queue reconnected"); });
-    this.mqttRed.on('close', function () { console.log("Queue disconnected");  });
-    this.mqttRed.on('offline', function () { console.log("Queue has gone offline");  });
-    
-    this.mqttRed.on('error', function (error: any) { 
-        console.log("error: " + error); 
+    this.mqttRed.on('close', function () { console.log("Queue disconnected"); });
+    this.mqttRed.on('offline', function () { console.log("Queue has gone offline"); });
+
+    this.mqttRed.on('error', function (error: any) {
+      console.log("error: " + error);
     });
-    
+
   }
+
+
 
 
 
 
   /* ################################################################################## */
 
-  register(cb:any) {
+  register(cb: any) {
     var packet = {
       "messageType": "Gateway.RegisterGatewayFromGateway.1",
-      "args": { "gateway": {
-        "GatewayId": this.GatewayId,
-        "Make" : this.Make,
-        "FirmwaveVersion": this.FirmwareVersion,
-        "Location": this.Location,
-        "Secret": this.secretkey,
-        "Devices": this.Devices,
-        "GatewayFirstContact": false,
-        "IsIoTHubDevice":false,
-        "ClientId": this.ClientId
-      }},
+      "args": {
+        "gateway": {
+          "GatewayId": this.GatewayId,
+          "Make": this.Make,
+          "FirmwaveVersion": this.FirmwareVersion,
+          "Location": this.Location,
+          "Secret": this.secretkey,
+          "Devices": this.Devices,
+          "GatewayFirstContact": false,
+          "IsIoTHubDevice": false,
+          "ClientId": this.ClientId
+        }
+      },
       "expiresAt": new Date(new Date().getTime() + 15 * 1000).toISOString()
     }
 
@@ -236,32 +236,33 @@ export class IotnxtQueue extends events.EventEmitter {
     var textBuffer = Buffer.from(JSON.stringify(packet));
 
     var wrappedMessage = {
-        Payload: textBuffer.toString("base64"),
-        IsEncrypted: false,
-        Headers: {},
-        PostUtc: new Date().toISOString(),
-        ReplyKey: "DAPI.1.DAPI.REPLY.1." + this.secret.ClientId.toUpperCase() + "." + StringUtils.getGUID().toUpperCase() + "." + StringUtils.getGUID().toUpperCase()
+      Payload: textBuffer.toString("base64"),
+      IsEncrypted: false,
+      Headers: {},
+      PostUtc: new Date().toISOString(),
+      ReplyKey: "DAPI.1.DAPI.REPLY.1." + this.secret.ClientId.toUpperCase() + "." + StringUtils.getGUID().toUpperCase() + "." + StringUtils.getGUID().toUpperCase()
     }
 
 
     var subtopic = wrappedMessage.ReplyKey.toUpperCase(); //.split(".").join("/").toUpperCase();
     var topic = "DAPI.1.Gateway.RegisterGatewayFromGateway.1." + this.secret.ClientId + ".DEFAULT"
 
-    
-      
+
+
     this.mqttRed.publish(topic.toUpperCase(), JSON.stringify(wrappedMessage), function (err: any) {
-      if (err) { console.log("ERROR:"); 
-          console.log(err); 
+      if (err) {
+        console.log("ERROR:");
+        console.log(err);
       } else {
-          cb(undefined, true); //SUCCESS
+        cb(undefined, true); //SUCCESS
       }
     });
-   
+
   }
 
   /* ################################################################################## */
 
-  public updateState(route:any, property:any,  data:any) {
+  public updateState(route: any, property: any, data: any) {
     console.log(this.GatewayId + " UPDATESTATE")
     //iotnxt.updateState(this.state, route, property, data );
 
@@ -270,11 +271,11 @@ export class IotnxtQueue extends events.EventEmitter {
     if (!this.state.deviceGroups[route]) { this.state.deviceGroups[route] = {}; }
     var before = this.state.deviceGroups[route][property];
     this.state.deviceGroups[route][property] = data;
-    
-    if (before != data) { 
-        return { updated: 1 } 
+
+    if (before != data) {
+      return { updated: 1 }
     } else {
-        return { updated: 0 }
+      return { updated: 0 }
     }
 
   }
@@ -283,22 +284,22 @@ export class IotnxtQueue extends events.EventEmitter {
 
   public publishState() {
     console.log(this.GatewayId + " PUBLISHING")
-    
 
-    var packet = JSON.parse(JSON.stringify(this.state)); 
+
+    var packet = JSON.parse(JSON.stringify(this.state));
     ///////
 
     packet.CommandText = "DigiTwin.Notification";
     packet.Headers = {
-        "FileName": "",
-        "Version": "2.15.0",
-        "Raptor": "000000000000"
+      "FileName": "",
+      "Version": "2.15.0",
+      "Raptor": "000000000000"
     };
 
     var dateNow = new Date();
     var fromUtc = new Date(dateNow.getTime() - 15 * 1000)
 
-    packet.MessageId  = StringUtils.getGUID();
+    packet.MessageId = StringUtils.getGUID();
     packet.PostUtc = dateNow.toISOString();
     packet.MessageSourceId = null;
     packet.fromUtc = fromUtc.toISOString();
@@ -309,10 +310,10 @@ export class IotnxtQueue extends events.EventEmitter {
     var textBuffer = Buffer.from(JSON.stringify(packet));
 
     var wrappedMessage = {
-        Payload: textBuffer.toString("base64"),
-        IsEncrypted: false,
-        Headers: {},
-        PostUtc: new Date().toISOString()
+      Payload: textBuffer.toString("base64"),
+      IsEncrypted: false,
+      Headers: {},
+      PostUtc: new Date().toISOString()
     }
 
     //Persist state before sending
@@ -320,53 +321,53 @@ export class IotnxtQueue extends events.EventEmitter {
 
     try {
 
-        var routingkey = this.secret.RoutingKeyBase + ".NFY"
+      var routingkey = this.secret.RoutingKeyBase + ".NFY"
 
-        console.log(routingkey);
-        this.mqttRed.publish(routingkey, JSON.stringify(wrappedMessage), { qos: 0 }, function (err:Error) {
-            if (err) { console.log("ERROR:" + err) }
-            
-        });
+      console.log(routingkey);
+      this.mqttRed.publish(routingkey, JSON.stringify(wrappedMessage), { qos: 0 }, function (err: Error) {
+        if (err) { console.log("ERROR:" + err) }
+
+      });
 
     } catch (err) {
-        console.error(`Failed to publish packet - \n Error : [${err}] \n [${JSON.stringify(wrappedMessage)}]`);
-     }
+      console.error(`Failed to publish packet - \n Error : [${err}] \n [${JSON.stringify(wrappedMessage)}]`);
+    }
 
 
   }
 
   /* ################################################################################## */
 
-  public registerEndpoints(deviceTree:any, cb:Function) {
+  public registerEndpoints(deviceTree: any, cb: Function) {
     console.log(this.GatewayId + " REGISTERING")
-    
+
     this.Devices = deviceTree;
     this.register(cb);
     //iotnxt.reRegister(deviceTree, cb)
   }
 
-} 
+}
 
 
 // callsback with this device's gateway
-export function findDeviceGateway(deviceState:any, db:any, serverGateways:any, cb:any) {
-  
+export function findDeviceGateway(deviceState: any, db: any, serverGateways: any, cb: any) {
+
   if (deviceState.iotnxtGatewayDefault) {
     cb(deviceState, deviceState.iotnxtGatewayDefault);
-  }  else {
+  } else {
     //check account setting
-    db.users.findOne({apikey:deviceState.apikey}, (err:Error, user:any) => {
-      if (user.iotnxtGatewayDefault) { 
+    db.users.findOne({ apikey: deviceState.apikey }, (err: Error, user: any) => {
+      if (user.iotnxtGatewayDefault) {
         //account has gateway set
-        cb(deviceState, user.iotnxtGatewayDefault); 
-      } else {  
+        cb(deviceState, user.iotnxtGatewayDefault);
+      } else {
         //account has no gateway set
         cb(deviceState, serverGateways[0]) //first in config serverwide
       }
     })
   }
 
-  
-} 
+
+}
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ var iotnxtqueue = new iotnxt.IotnxtQueue(
     GatewayId: "TutorialGateway01",
     //secret is your password to connect the Gateway, this cannot be changed , dont share with anyone!
     secretkey: "166123181241239",
-    FirmwareVersion: "5.0.25",
+    FirmwareVersion: "5.0.26",
     Make:  "Pi Gateway",
     Model: "nodejs client",
     id: "Pi 3 B",

--- a/src/tests/queue.test.ts
+++ b/src/tests/queue.test.ts
@@ -1,56 +1,41 @@
-import * as iotnxt from "./iotnxt/iotnxt";
+import { IotnxtQueue } from '../iotnxt/iotnxt'
+import { expect } from 'chai';
+import 'mocha';
 
 var deviceTree = {};
 deviceTree["House|1:Appliances|1"] = {
-  Make: "Pi Gateway",
-  Model: "Pi 3 B",
-  DeviceName: "Kichen|1:Stove|1",
-  DeviceType: "Stove",
-  Properties: {
-    StoveLight: {
-      PropertyName: "StoveLight",
-      DataType: null
+    Make: "Pi Gateway",
+    Model: "Pi 3 B",
+    DeviceName: "Kichen|1:Stove|1",
+    DeviceType: "Stove",
+    Properties: {
+        StoveLight: {
+            PropertyName: "StoveLight",
+            DataType: null
+        }
     }
-  }
 };
 
-var iotnxtqueue = new iotnxt.IotnxtQueue(
-  {
+let mockConfig: any = {
     //Gateway Id , this MUST be unique for every pi/gateway unit
     GatewayId: "TutorialGateway01",
     //secret is your password to connect the Gateway, this cannot be changed , dont share with anyone!
     secretkey: "166123181241239",
     FirmwareVersion: "5.0.26",
-    Make:  "Pi Gateway",
+    Make: "Pi Gateway",
     Model: "nodejs client",
     id: "Pi 3 B",
     publickey: "<RSAKeyValue><Exponent>AQAB</Exponent><Modulus>rbltknM3wO5/TAEigft0RDlI6R9yPttweDXtmXjmpxwcuVtqJgNbIQ3VduGVlG6sOg20iEbBWMCdwJ3HZTrtn7qpXRdJBqDUNye4Xbwp1Dp+zMFpgEsCklM7c6/iIq14nymhNo9Cn3eBBM3yZzUKJuPn9CTZSOtCenSbae9X9bnHSW2qB1qRSQ2M03VppBYAyMjZvP1wSDVNuvCtjU2Lg/8o/t231E/U+s1Jk0IvdD6rLdoi91c3Bmp00rVMPxOjvKmOjgPfE5LESRPMlUli4kJFWxBwbXuhFY+TK2I+BUpiYYKX+4YL3OFrn/EpO4bNcI0NHelbWGqZg57x7rNe9Q==</Modulus></RSAKeyValue>",
     hostaddress: "greenqueue.prod.iotnxt.io"
-  },
-  deviceTree,
-  true
-);
+}
 
-//Main init entry point
-iotnxtqueue.init();
-//
+let queueClient = new IotnxtQueue(mockConfig, deviceTree, true);
 
 
-
-
-iotnxtqueue.on("connect", ()=>{
-  console.log("CONNECTED...")
-//The following interval will send values to the pllatfor every 2,5 seconds 
-  setInterval(()=>{
-    console.log("sending data...")
-    iotnxtqueue.updateState("Kichen|1:Stove|1", "StoveLight", Math.random())
-    iotnxtqueue.publishState();
-  },2500)
-
-  // Logs out incoming requests from commander
-  iotnxtqueue.on('request', (request:any) => {
-    console.log("REQUEST:")
-    console.log(request);
-  });
-  
-})
+describe('Queue Client Tests', () => {
+    it('connectGreenQ : Connect to public Green Queue [mock config]', () => {
+        queueClient.connectGreenQ((data) => {
+            expect(data.Success).to.equal(true)
+        })
+    });
+});

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,0 +1,14 @@
+import { StringUtils } from '../utils/string.utils'
+import { expect } from 'chai';
+import 'mocha';
+
+describe('String Util tests:', () => {
+  it('getGUID : Generate unique strings', () => {
+    let originalString = StringUtils.getGUID();
+    let isDuplicate = false;
+    for (let i = 0; i < 100000; i++) {
+      originalString == StringUtils.getGUID() ? isDuplicate = true : null;
+    }
+    expect(isDuplicate).to.equal(false);
+  });
+});

--- a/src/utils/crypto.utils.ts
+++ b/src/utils/crypto.utils.ts
@@ -1,0 +1,67 @@
+import crypto = require("crypto");
+
+
+export interface RSAcredentials {
+    modulus: string,
+    exponent: string
+}
+
+export class CryptoUtils {
+    
+    public static RSAENCRYPT(text: string, credentials: RSAcredentials) {
+        // https://stackoverflow.com/questions/27568570/how-to-convert-raw-modulus-exponent-to-rsa-public-key-pem-format
+    
+        var publicKey = this.RSAgenPEM(credentials.modulus, credentials.exponent);
+        var buffer = Buffer.from(text);
+    
+        var rsakey = {
+            key: publicKey,
+            padding: 1 //crypto.constants.RSA_PKCS1_PADDING  
+        }
+    
+        //An optional padding value defined in crypto.constants, which may be: crypto.constants.RSA_NO_PADDING, RSA_PKCS1_PADDING, or crypto.constants.RSA_PKCS1_OAEP_PADDING.
+    
+        var encrypted = crypto.publicEncrypt(rsakey, buffer);
+        return encrypted.toString("base64");
+    }
+    
+    public static  RSAgenPEM(modulus: string, exponent: string) {
+        // by Rouan van der Ende
+        // converts a raw modulus/exponent public key to a PEM format.
+    
+        var header = Buffer.from("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA", 'base64'); //Standard header
+        var mod = Buffer.from(modulus, 'base64');
+        var midHeader = Buffer.from([0x02, 0x03]);
+        var exp = Buffer.from(exponent, 'base64');
+    
+        //combine
+        var key = Buffer.concat([header, mod, midHeader, exp])
+        var keybase64 = key.toString("base64");
+    
+        var PEM = "-----BEGIN PUBLIC KEY-----\r\n"
+    
+        for (var a = 0; a <= Math.floor(keybase64.length / 64); a++) {
+            PEM += keybase64.slice(0 + (64 * a), 64 + (64 * a)) + "\r\n";
+        }
+    
+        PEM += "-----END PUBLIC KEY-----\r\n"
+    
+        return PEM;
+    }
+    
+    public static  genAESkeys (callback:any) {
+          crypto.pseudoRandomBytes(32, function (err, keyBuffer) {
+              crypto.pseudoRandomBytes(16, function (err, ivBuffer) {
+                  callback({ key: keyBuffer, iv: ivBuffer });
+              });
+          });
+    }
+    
+    public static  createCipheriv(AES: any, algorithm: string = "aes-256-cbc"): crypto.Cipher {
+        return crypto.createCipheriv(algorithm, AES.key, AES.iv);
+    }
+    
+    public static  createDecipheriv(AES: any, algorithm: string = "aes-256-cbc"): crypto.Decipher {
+        return crypto.createDecipheriv(algorithm, AES.key, AES.iv);
+    }
+}

--- a/src/utils/string.utils.ts
+++ b/src/utils/string.utils.ts
@@ -1,0 +1,11 @@
+export class StringUtils {
+    public static  getGUID() {
+        var d = new Date().getTime();
+        var uuid: string = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = (d + Math.random() * 16) % 16 | 0;
+            d = Math.floor(d / 16);
+            return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+        });
+        return uuid;
+      };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": [
+      "es2015"
+    ],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./build",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "rootDirs": ["src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+ "include": [
+   "src/**/*.ts"
+ ] 
+}

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "chai": "registry:npm/chai#3.5.0+20160723033700"
+  }
+}


### PR DESCRIPTION
Featured changes (Builds on top of changes in PR #2) 
----

#### Additions
* Add basic mocha unit tests for string utils and queue code
* ```.vscode``` config folder for debugging from VS Code
* ```.tsconfig``` file for debugging from VS Code and ```npm run build``` command
* ```test``` and ```build``` script added to ```package.json``` setup

----
#### Refactor/Changes
* Move constructor code of queueClient into ```init()``` function to enable better seperation and unit testing of client code
----
#### Fixes
* Move 'sqlite' feature to 'planned' in README as feature is not present in this build...

